### PR TITLE
simple_aggregates: add string_agg aggregate

### DIFF
--- a/conf/mz/simple-aggregates.yy
+++ b/conf/mz/simple-aggregates.yy
@@ -108,6 +108,7 @@ aggregate_list:
 ;
 
 aggregate_item_no_window:
+	ARRAY_LENGTH ( array_generating_aggregate_func ( select_item ), 1 ) |
 	aggregate_func ( distinct select_item ) |
 	aggregate_func ( distinct select_item ) |
 	aggregate_func ( distinct select_item ) |
@@ -117,6 +118,11 @@ aggregate_item_no_window:
 aggregate_func:
 	MIN | MAX | COUNT | AVG
 ;
+
+array_generating_aggregate_func:
+	ARRAY_AGG
+;
+
 
 select_item_list:
 	(a1.f1) AS c1, (a2.f1) AS c2, (a1.f2) AS c3 |

--- a/conf/mz/simple-aggregates.yy
+++ b/conf/mz/simple-aggregates.yy
@@ -108,6 +108,8 @@ aggregate_list:
 ;
 
 aggregate_item_no_window:
+    # aggregation that returns a number (needs substring with start at index 3 to cut \x away (yes, three characters needed for that), limit the length to stay in range of INT8)
+    TRANSLATE(SUBSTRING(SHA256(STRING_AGG(select_item::TEXT, '-' ORDER BY select_item)::BYTEA)::TEXT, 3, 16), 'abcdef', '123456')::INT8 |
 	ARRAY_LENGTH ( array_generating_aggregate_func ( select_item ), 1 ) |
 	aggregate_func ( distinct select_item ) |
 	aggregate_func ( distinct select_item ) |


### PR DESCRIPTION
```
SELECT
    translate(
        substring(
            -- start at index 3 to cut \x away (yes, three characters needed for that), limit the length to stay in range of INT8
            sha256(string_agg(x::text, '-' ORDER BY x)::bytea)::text, 3, 16
        ),
        'abcdef',
        '123456'
    )::int8
FROM t;
```

https://materializeinc.slack.com/archives/C0761MZ3QD9/p1721311470141489?thread_ts=1721267616.770529&cid=C0761MZ3QD9