### PR TITLE
mz/wmr: use `UNION` instead of `UNION ALL`

### DIFF
--- a/conf/mz/with-mutually-recursive.yy
+++ b/conf/mz/with-mutually-recursive.yy
@@ -85,7 +85,7 @@ cte_select_list_aggregate:
 ;
 
 cte_definition:
-    cte_constant UNION all cte_select
+    cte_constant UNION cte_select
 ;
 
 all:


### PR DESCRIPTION
To reduce the likelyhood over diff overflows.

Part of fixing https://github.com/MaterializeInc/database-issues/issues/7433.