### PR TITLE
WMR: Don't use serializable transaction isolation

### DIFF
--- a/conf/mz/with-mutually-recursive.yy
+++ b/conf/mz/with-mutually-recursive.yy
@@ -6,15 +6,7 @@
 #
 
 thread1_init:
-    set_serializable ; DROP TABLE IF EXISTS t1 CASCADE ; CREATE TABLE t1 ( t1_definition ) ; CREATE INDEX i1 ON t1 ( index_definition ) ; INSERT INTO t1 VALUES insert_list
-;
-
-query_init:
-    set_serializable
-;
-
-set_serializable:
-    SET transaction_isolation = SERIALIZABLE
+    DROP TABLE IF EXISTS t1 CASCADE ; CREATE TABLE t1 ( t1_definition ) ; CREATE INDEX i1 ON t1 ( index_definition ) ; INSERT INTO t1 VALUES insert_list
 ;
 
 explain:


### PR DESCRIPTION
Seen in https://github.com/MaterializeInc/database-issues/issues/9439

My understanding is that `t1` was missing when running the query, thus it failed, causing RQG to recreate the table, thus causing the apparent wrong results in the other running threads. In the end this seems to be badly designed in RQG, but I'm not that familiar with the design to fix it in another way.